### PR TITLE
Add exception for failed creation

### DIFF
--- a/lib/resources/Request_Write.rb
+++ b/lib/resources/Request_Write.rb
@@ -14,7 +14,7 @@ module CoresenseRest
     def create
       response = HTTParty.post(@root, body: @data.to_json, headers: @headers, format: :json, timeout: 120)
       raise "#{response.parsed_response} code: #{response.code} \n payload: #{@data.to_json}" unless response.code >= 200 && response.code < 300
-
+      raise "No id returned, object creation failed" if (id = response.parsed_response['id']).nil?
       @request_class.find(response.parsed_response['id'])
       # RequestRead.new(response.parsed_response['uri'], @headers, @request_class).select
     end


### PR DESCRIPTION
Added exception to note when order creation fails, since the application server will return a success code even if object creation fails under some circumstances