### PR TITLE
add voiding orders

### DIFF
--- a/lib/coresense_rest.rb
+++ b/lib/coresense_rest.rb
@@ -11,7 +11,7 @@ module CoresenseRest
   class HttpError < Error
     attr_reader :response
 
-    def self.new(msg, response = nil)
+    def initialize(msg, response = nil)
       @response = response
       super msg
     end

--- a/lib/resources/request_write.rb
+++ b/lib/resources/request_write.rb
@@ -25,7 +25,7 @@ module CoresenseRest
       response = HTTParty.put(@root, body: @data.to_json, headers: @headers, format: :json)
       raise response_error(response) unless response.code == 200
 
-      JSON.parse(response.parsed_response)
+      response.parsed_response
     rescue JSONParseError::Rescuable => e
       raise JSONParseError.new(e.message, response)
     end

--- a/lib/resources/resources.rb
+++ b/lib/resources/resources.rb
@@ -191,6 +191,10 @@ module CoresenseRest
     def shipments
       RequestRead.new("#{Order.full_path}/#{id}/shipment", Product.headers, Shipment).select
     end
+
+    def void
+      RequestWrite.new("#{Order.full_path}Void/#{id}", Order.headers, self, nil).update
+    end
   end
 
   class OrderShippingDetail < Resource

--- a/spec/lib/resources/resources_spec.rb
+++ b/spec/lib/resources/resources_spec.rb
@@ -378,6 +378,17 @@ module CoresenseRest
             expect(shipments[0]).to be_an_instance_of(Shipment)
           end
         end
+
+        it 'Voids an order.' do
+          VCR.use_cassette("#{described_class.name.split('::').last}/void") do
+            order = Order.find(9000)
+            
+            result = order.void
+            
+            result_hash = JSON.parse(result.body)
+            expect(result_hash["message"]).to eq 'Order has been voided successfully.'
+          end
+        end
       end
 
       context OrderShippingDetail do


### PR DESCRIPTION
## Ticket
[NEB-85](https://fcpeuro.atlassian.net/browse/NEB-85)

## Change Type
 Feature 🏎️

## Migrations (Yes or No)? 🚚
no

## Stakeholder Approvals
no

## Description
This PR adds voiding an order. 
Also, this fixes the HttpError Initializer because that did not actually use the new method that was in there.
Now we can access the response from the error.

## References
https://api-fcpuat.coresense.com/#ordervoid


[NEB-85]: https://fcpeuro.atlassian.net/browse/NEB-85?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ