### PR TITLE
With updatable shipments

### DIFF
--- a/lib/resources/resources.rb
+++ b/lib/resources/resources.rb
@@ -285,6 +285,8 @@ module CoresenseRest
   class Shipment < Resource
     extend Searchable
     extend Findable
+    extend Updatable
+
     attr_accessor :arrival_date, :assoc_entity, :assoc_entity_id, :carrier_account_id,
                   :cod_tracking_num, :cost, :destination, :destination_id, :exported, :id,
                   :method_id, :needs_recalculation, :picked_up_date, :ship_date,

--- a/lib/resources/updatable.rb
+++ b/lib/resources/updatable.rb
@@ -4,8 +4,7 @@ module CoresenseRest
   module Updatable
     def update(body)
       if body.is_a? Hash
-        body[:id] = self.id
-        RequestWrite.new(full_path, headers, self, body).update
+        RequestWrite.new("#{full_path}/#{body[:id]}", headers, self, body).update
       else
         raise ArgumentError, "Expected Hash, got #{body.class.name}"
       end


### PR DESCRIPTION
This fixes the updatable module. Also it makes shipments updatable.
We need this in order to have parsec be able to update the shipment status via rest api.

I already tested this. I works.

Updating a shipment works like:
```
cs=CoresenseRest::Shipment.find(30937010)
=> #<CoresenseRest::Shipment custom_shipium_id="", custom_shipment_cube="", custom_shipment_pick_area="", pack_confirmation_stamp="0000-00-00 00:00:00", pack_confirmation_user_...

cs.status
=> "new"

cs_update_hash= {id: s.id, status: 'shipped'}
=> {:id=>30937010, :status=>"shipped"}
CoresenseRest::Shipment.update(cs_update_hash)
=> nil

cs=CoresenseRest::Shipment.find(30937010)
=> #<CoresenseRest::Shipment custom_shipium_id="", custom_shipment_cube="", custom_shipment_pick_area="", pack_confirmation_stamp="0000-00-00 00:00:00", pack_confirmation_user_...

cs.status
=> "shipped"
```